### PR TITLE
Support for io-ts@2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It provides the following:
 
 ### Promise chain decoding
 
-Decode data from Promise based APIs, without having to worry about how to retrieve data from the [Either](https://github.com/gcanti/fp-ts/blob/master/docs/Either.md) values returned by the `io-ts` types.
+Decode data from Promise based APIs, without having to worry about how to retrieve data from the [Either](https://gcanti.github.io/fp-ts/modules/Either.ts.html) values returned by the `io-ts` types.
 
 ```typescript
 import * as t from 'io-ts';

--- a/package-lock.json
+++ b/package-lock.json
@@ -376,12 +376,6 @@
         "is-buffer": "~2.0.3"
       }
     },
-    "fp-ts": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.0.tgz",
-      "integrity": "sha512-8I22IXnAQbNzShKhrk506iHXftsJLDjyLMyaNYJwvY9jWhDUVghQZ0F9QX0XU9wRM1NzQpOCTYN39NBQq/2Gxw==",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint:typescript": "tsc --noEmit",
     "test:js": "mocha -r ts-node/register test/*.ts",
     "build": "tsc",
-    "installPeerDepenencies": "npm install --no-save io-ts@2.x fp-ts@2.x",
-    "prepublish": "npm run installPeerDepenencies && npm run build"
+    "installPeerDependencies": "npm install --no-save io-ts@2.x fp-ts@2.x",
+    "prepublish": "npm run installPeerDependencies && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:typescript": "tsc --noEmit",
     "test:js": "mocha -r ts-node/register test/*.ts",
     "build": "tsc",
-    "installPeerDepenencies": "npm install --no-save io-ts@1.x",
+    "installPeerDepenencies": "npm install --no-save io-ts@2.x fp-ts@2.x",
     "prepublish": "npm run installPeerDepenencies && npm run build"
   },
   "repository": {
@@ -36,7 +36,8 @@
     "deep-equal": "^1.0.1"
   },
   "peerDependencies": {
-    "io-ts": "1.x"
+    "fp-ts": "2.x",
+    "io-ts": "2.x"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -45,7 +46,6 @@
     "@types/mocha": "^5.2.7",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "fp-ts": "^1.19.0",
     "mocha": "^6.1.4",
     "prettier": "^1.18.2",
     "ts-node": "^8.3.0",

--- a/test/helpers/chai-fp-ts.ts
+++ b/test/helpers/chai-fp-ts.ts
@@ -22,16 +22,23 @@ interface Utils {
 export default function(chai: Chai, utils: Utils) {
   const Assertion = chai.Assertion;
 
+  function isObject(value: unknown): value is object {
+    return typeof value === 'object' && value !== null;
+  }
+
   function isEither<L, A>(value: unknown): value is Either.Either<L, A> {
-    return value instanceof Either.Left || value instanceof Either.Right;
+    if (!isObject(value)) {
+      return false;
+    }
+    return Either.isLeft(value as any) || Either.isRight(value as any);
   }
 
   Assertion.addProperty('left', function() {
     const obj = this._obj;
     let isLeft: boolean = false;
 
-    if (isEither(obj) && obj.isLeft()) {
-      utils.flag(this, 'object', obj.value);
+    if (isEither(obj) && Either.isLeft(obj)) {
+      utils.flag(this, 'object', obj.left);
       isLeft = true;
     }
 
@@ -46,8 +53,8 @@ export default function(chai: Chai, utils: Utils) {
     const obj = this._obj;
     let isRight: boolean = false;
 
-    if (isEither(obj) && obj.isRight()) {
-      utils.flag(this, 'object', obj.value);
+    if (isEither(obj) && Either.isRight(obj)) {
+      utils.flag(this, 'object', obj.right);
       isRight = true;
     }
 


### PR DESCRIPTION
This PR adds support for io-ts version 2.0.

# Notable changes:

* calls to `Either.prototype.chain` and `Either.prototype.fold` are replaced with fp-ts `either.chain` and `fold` functions
* chai assertions for `Either` updated to match the changes in fp-ts
* broken link to Either.ts docs (issue #10) fixed in README.md