### PR TITLE
Fix decoding of "falsy" values for simple types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export function decode<Output, Input>(
       return fold<t.Errors, Output, Promise<Output>>(
         errors => Promise.reject(new DecodeError(errors)),
         decodedValue => Promise.resolve(decodedValue),
-      )(type.decode(value || arguments[2]));
+      )(type.decode(value === undefined ? arguments[2] : value));
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export function decode<Output, Input>(
       return fold<t.Errors, Output, Promise<Output>>(
         errors => Promise.reject(new DecodeError(errors)),
         decodedValue => Promise.resolve(decodedValue),
-      )(type.decode(value === undefined ? arguments[2] : value));
+      )(type.decode(value || arguments[1]));
   }
 }
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -204,6 +204,27 @@ describe('io-ts-promise', () => {
       return expect(tPromise.decode(type, value)).to.eventually.equal(value);
     });
 
+    it('resolves promise on falsy string', () => {
+      const type = t.string;
+      const value = '';
+
+      return expect(tPromise.decode(type, value)).to.eventually.equal(value);
+    });
+
+    it('resolves promise on falsy boolean', () => {
+      const type = t.boolean;
+      const value = false;
+
+      return expect(tPromise.decode(type, value)).to.eventually.equal(value);
+    });
+
+    it('resolves promise on falsy number', () => {
+      const type = t.number;
+      const value = 0;
+
+      return expect(tPromise.decode(type, value)).to.eventually.equal(value);
+    });
+
     it('rejects promise on invalid data', () => {
       const type = t.string;
       const value = 10;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -225,6 +225,20 @@ describe('io-ts-promise', () => {
       return expect(tPromise.decode(type, value)).to.eventually.equal(value);
     });
 
+    it('resolves promise on falsy undefined', () => {
+      const type = t.undefined;
+      const value = undefined;
+
+      return expect(tPromise.decode(type, value)).to.eventually.equal(value);
+    });
+
+    it('resolves promise on falsy null', () => {
+      const type = t.null;
+      const value = null;
+
+      return expect(tPromise.decode(type, value)).to.eventually.equal(value);
+    });
+
     it('rejects promise on invalid data', () => {
       const type = t.string;
       const value = 10;


### PR DESCRIPTION
"Falsy" values ('', false and 0) where mistakenly replaced with
`undefined` due to a bug when trying to decode "simple" primitive
types (did not affect combined types).