### PR TITLE
Properly extend Error in DecodeError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,14 +55,14 @@ export function isDecodeError(error: unknown): error is DecodeError {
  * Custom error class which is rejected by the @see decode function
  * when decoding fails due to invalid data.
  */
-export class DecodeError implements Error {
+export class DecodeError extends Error {
   public name = 'DecodeError';
-  public message: string;
   public errors: t.Errors;
 
   constructor(errors: t.Errors) {
-    this.message = PathReporter.report(t.failures(errors)).join('\n');
+    super(PathReporter.report(t.failures(errors)).join('\n'));
     this.errors = errors;
+    Object.setPrototypeOf(this, DecodeError.prototype);
   }
 }
 


### PR DESCRIPTION
This is compatible with the latest version of TypeScript, but will also not break older versions.

See: https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work

This removes the custom property `message` in favour of using the constructor for `Error` which will both set `message` and override `toString`.