### PR TITLE
remove naive is implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ const Price = tPromise.createType(
   },
   // Encode function does the reverse
   price => price.amount,
-    // Type guard function
+  // Type guard function
   t.type({ currency: t.string, amount: t.number }).is,
 );
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fetch('http://example.com/api/not-a-person')
 
 ### Creating custom types
 
-Writing custom `io-ts` types is a bit cryptic, so this library provides a simpler way of extending existing `io-ts` types, or creating your own from scratch. All you need is a function which decodes incoming values, and another which encodes it back.
+Writing custom `io-ts` types is a bit cryptic, so this library provides a simpler way of extending existing `io-ts` types, or creating your own from scratch. All you need are the functions for transforming values to and from the base type, as well as a type guard function to check whether a value adheres to the type.
 
 ```typescript
 import * as t from 'io-ts';
@@ -126,6 +126,8 @@ const Price = tPromise.createType(
   },
   // Encode function does the reverse
   price => price.amount,
+    // Type guard function
+  t.type({ currency: t.string, amount: t.number }).is,
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ fetch('http://example.com/api/product')
   );
 ```
 
+Or if you are working with classes instead of objects:
+
+```typescript
+import * as t from 'io-ts';
+import * as tPromise from 'io-ts-promise';
+
+// New type extending from existing type
+const RegExpType = tPromise.extendType(
+  t.string,
+  // Decode function takes in string and produces class
+  (value: string) => new RegExp(value),
+  // Encode function does the reverse
+  regexp => regexp.source,
+  // Type guard function
+  (value): value is RegExp => value instanceof RegExp,
+);
+```
+
 Alternatively, you can define the type from scratch, in which case the decoder will receive a value of `unknown` type to decode into desired runtime type.
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ const Price = tPromise.extendType(
   }),
   // Encode function does the reverse
   price => price.amount,
+  // Type guard function
+  t.type({ currency: t.string, amount: t.number }).is,
 );
 
 // And use them as part of other types

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,7 +263,8 @@
       "version": "4.3.20",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
       "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/chai-subset": {
       "version": "1.3.6",
@@ -288,7 +289,8 @@
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
       "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/semver": {
       "version": "7.7.1",
@@ -319,6 +321,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -459,7 +462,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -663,32 +667,11 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      }
-    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -743,6 +726,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1099,11 +1083,6 @@
       "dev": true,
       "optional": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
     "get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -1162,14 +1141,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1215,16 +1186,6 @@
       "peer": true,
       "requires": {}
     },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1251,14 +1212,6 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "^1.0.1"
-      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -1432,16 +1385,6 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
-    "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1595,14 +1538,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-      "requires": {
-        "define-properties": "^1.1.2"
-      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -1782,7 +1717,8 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "ufo": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "url": "https://github.com/aeirola/io-ts-promise/issues"
   },
   "homepage": "https://github.com/aeirola/io-ts-promise",
-  "dependencies": {
-    "deep-equal": "^1.1.0"
-  },
   "peerDependencies": {
     "fp-ts": "2.x",
     "io-ts": "2.x"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -137,6 +137,25 @@ describe('io-ts-promise', () => {
       return expect(result).resolves.toEqual('Product costs 10 EUR');
     });
 
+    it('provides creating custom class by extending existing types', () => {
+      // New type extending from existing type
+      const RegExpType = tPromise.extendType(
+        t.string,
+        // Decode function takes in string and produces class
+        (value: string) => new RegExp(value),
+        // Encode function does the reverse
+        (regexp) => regexp.source,
+        // Type guard function
+        (value): value is RegExp => value instanceof RegExp,
+      );
+
+      const result = tPromise
+        .decode(RegExpType, '^test-[0-9]')
+        .then((regExp) => regExp.exec('test-5: regexps')?.[0]);
+
+      return expect(result).resolves.toEqual('test-5');
+    });
+
     it('provides creating custom types from scratch', () => {
       // Custom type from scratch
       const Price = tPromise.createType(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -116,6 +116,8 @@ describe('io-ts-promise', () => {
         }),
         // Encode function does the reverse
         (price) => price.amount,
+        // Type guard function
+        t.type({ currency: t.string, amount: t.number }).is,
       );
 
       // And use them as part of other types
@@ -151,6 +153,8 @@ describe('io-ts-promise', () => {
         },
         // Encode function does the reverse
         (price) => price.amount,
+        // Type guard function
+        t.type({ currency: t.string, amount: t.number }).is,
       );
 
       // And use them as part of other types
@@ -290,6 +294,7 @@ describe('io-ts-promise', () => {
         }
       },
       (value) => value.value,
+      t.type({ currency: t.string, value: t.number }).is,
     );
 
     runPriceTypeTests(price);
@@ -303,6 +308,7 @@ describe('io-ts-promise', () => {
         value,
       }),
       (value) => value.value,
+      t.type({ currency: t.string, value: t.number }).is,
     );
 
     runPriceTypeTests(price);
@@ -372,8 +378,8 @@ describe('io-ts-promise', () => {
 
       expect(
         price.is({
-          currency: 'USD',
-          value: 10,
+          currency: 'EUR',
+          value: '10€',
         }),
       ).toEqual(false);
     });


### PR DESCRIPTION
The naive implementation was unsafe as it didn't consistently handle all use cases.

This will be a breaking change and cause the next version to be 3.0.0